### PR TITLE
Fixed data feed missing on install

### DIFF
--- a/domains_plugin.php
+++ b/domains_plugin.php
@@ -44,6 +44,7 @@ class DomainsPlugin extends Plugin
 
         Configure::load('domains', dirname(__FILE__) . DS . 'config' . DS);
 
+        $this->upgrade1_5_0();
         try {
             // domains_tlds
             $this->Record
@@ -137,7 +138,6 @@ class DomainsPlugin extends Plugin
             }
         }
 
-        $this->upgrade1_5_0();
         $this->upgrade1_6_2();
         $this->upgrade1_8_0();
 


### PR DESCRIPTION
Moves the `upgrade1_5_0()` call to run before the install table-creation logic so the data feed is registered correctly on install.